### PR TITLE
Add Kosovo temporary country code

### DIFF
--- a/callcodes.go
+++ b/callcodes.go
@@ -151,6 +151,7 @@ const (
 	CallCode380     CallCode = 380
 	CallCode381     CallCode = 381
 	CallCode382     CallCode = 382
+	CallCode383     CallCode = 383
 	CallCode385     CallCode = 385
 	CallCode386     CallCode = 386
 	CallCode387     CallCode = 387
@@ -275,7 +276,7 @@ func (c CallCode) Info() *CallCodeInfo {
 
 // TotalCallCodes - returns number of call codes in the package, countries.TotalCallCodes() == len(countries.AllCallCodes()) but static value for perfomance
 func TotalCallCodes() int {
-	return 230
+	return 231
 }
 
 // AllCallCodes - return all countries call phone codes
@@ -409,6 +410,7 @@ func AllCallCodes() []CallCode {
 		CallCode380,
 		CallCode381,
 		CallCode382,
+		CallCode383,
 		CallCode385,
 		CallCode386,
 		CallCode387,
@@ -751,6 +753,8 @@ func (c CallCode) Countries() []CountryCode {
 		return []CountryCode{SRB}
 	case CallCode382:
 		return []CountryCode{MNE}
+	case CallCode383:
+		return []CountryCode{XKX}
 	case CallCode385:
 		return []CountryCode{HRV}
 	case CallCode386:

--- a/capitals.go
+++ b/capitals.go
@@ -276,6 +276,7 @@ const (
 	CapitalMF      CapitalCode = CapitalCode(MF)
 	CapitalSS      CapitalCode = CapitalCode(SS)
 	CapitalJP      CapitalCode = CapitalCode(JP)
+	CapitalXK      CapitalCode = CapitalCode(XK)
 )
 
 // Type implements Typer interface
@@ -788,6 +789,8 @@ func (c CapitalCode) String() string {
 		return "Juba"
 	case CapitalJP:
 		return "Tokyo"
+	case CapitalXK:
+		return "Pristina"
 	}
 	return UnknownMsg
 }
@@ -1297,6 +1300,8 @@ func (c CapitalCode) Country() CountryCode {
 		return SS
 	case CapitalJP:
 		return JP
+	case CapitalXK:
+		return XK
 	}
 	return Unknown
 }
@@ -1598,6 +1603,7 @@ func AllCapitals() []CapitalCode {
 		CapitalMF,
 		CapitalSS,
 		CapitalJP,
+		CapitalXK,
 	}
 }
 
@@ -2100,6 +2106,8 @@ func CapitalCodeByName(name string) CapitalCode {
 		return CapitalZM
 	case "HARARE":
 		return CapitalZW
+	case "PRISTINA":
+		return CapitalXK
 	}
 	return CapitalUnknown
 }

--- a/countries.go
+++ b/countries.go
@@ -225,6 +225,7 @@ const (
 	Kiribati                               CountryCode = 296
 	Korea                                  CountryCode = 410
 	KoreaNorth                             CountryCode = 408
+	Kosovo                                 CountryCode = 900
 	Kuwait                                 CountryCode = 414
 	Kyrgyzstan                             CountryCode = 417
 	Laos                                   CountryCode = 418
@@ -483,6 +484,7 @@ const (
 	KI CountryCode = 296
 	KR CountryCode = 410
 	KP CountryCode = 408
+	XK CountryCode = 900
 	KW CountryCode = 414
 	KG CountryCode = 417
 	LA CountryCode = 418
@@ -739,6 +741,7 @@ const (
 	KIR CountryCode = 296
 	KOR CountryCode = 410
 	PRK CountryCode = 408
+	XKX CountryCode = 900
 	KWT CountryCode = 414
 	KGZ CountryCode = 417
 	LAO CountryCode = 418
@@ -885,7 +888,7 @@ const (
 
 // Total - returns number of codes in the package, countries.Total() == len(countries.All()) but static value for perfomance
 func Total() int {
-	return 253
+	return 254
 }
 
 // Emoji - return a country Alpha-2 (ISO2) as Emoji flag (example "RU" as "🇷🇺")
@@ -1137,6 +1140,8 @@ func (c CountryCode) String() string {
 		return "Korea (Republic of)"
 	case 408:
 		return "Korea (Democratic People's Republic of)"
+	case 900:
+		return "Kosovo"
 	case 414:
 		return "Kuwait"
 	case 417:
@@ -1646,6 +1651,8 @@ func (c CountryCode) StringRus() string {
 		return "Корея"
 	case 408:
 		return "Корейская Народная Демократическая республика"
+	case 900:
+		return "Косово"
 	case 414:
 		return "Кувейт"
 	case 417:
@@ -2157,6 +2164,8 @@ func (c CountryCode) Alpha2() string {
 		return "KR"
 	case 408:
 		return "KP"
+	case 900:
+		return "XK"
 	case 414:
 		return "KW"
 	case 417:
@@ -2666,6 +2675,8 @@ func (c CountryCode) Alpha3() string {
 		return "KOR"
 	case 408:
 		return "PRK"
+	case 900:
+		return "XKX"
 	case 414:
 		return "KWT"
 	case 417:
@@ -3153,6 +3164,8 @@ func (c CountryCode) Currency() CurrencyCode {
 		return CurrencyXOF
 	case CUB:
 		return CurrencyCUC
+	case XKX:
+		return CurrencyEUR
 	case KWT:
 		return CurrencyKWD
 	case KGZ:
@@ -4205,6 +4218,8 @@ func (c CountryCode) CallCode() CallCode {
 		return CallCode(211)
 	case JPN:
 		return CallCode(81)
+	case XKX:
+		return CallCode(383)
 	}
 	return 0
 }
@@ -4723,6 +4738,8 @@ func (c CountryCode) Region() RegionCode {
 		return RegionAF
 	case JPN:
 		return RegionAS
+	case XKX:
+		return RegionEU
 	}
 	return RegionUnknown
 }
@@ -5232,6 +5249,8 @@ func (c CountryCode) Capital() CapitalCode {
 		return CapitalSS
 	case JPN:
 		return CapitalJP
+	case XKX:
+		return CapitalXK
 	}
 	return CapitalUnknown
 }
@@ -5816,6 +5835,8 @@ func ByName(name string) CountryCode {
 		return SSD
 	case "JP", "JPN", "JAPAN":
 		return JPN
+	case "XK", "XKX", "KOSOVO":
+		return XK
 	}
 	return Unknown
 }

--- a/domains.go
+++ b/domains.go
@@ -289,6 +289,7 @@ const (
 	DomainMF      DomainCode = DomainCode(MF)
 	DomainSS      DomainCode = DomainCode(SS)
 	DomainJP      DomainCode = DomainCode(JP)
+	DomainXK      DomainCode = DomainCode(XK)
 )
 
 // Type implements Typer interface
@@ -644,6 +645,7 @@ func AllDomains() []DomainCode {
 		DomainMF,
 		DomainSS,
 		DomainJP,
+		DomainXK,
 	}
 }
 
@@ -659,5 +661,5 @@ func AllDomainsInfo() []*Domain {
 
 // TotalDomains - returns number of domains in the package, countries.TotalDomains() == len(countries.AllDomains()) but static value for perfomance
 func TotalDomains() int {
-	return 263
+	return 264
 }


### PR DESCRIPTION
I chose the country code 900 because as stated in [this post from geonames](https://geonames.wordpress.com/2010/03/08/xk-country-code-for-kosovo/) codes between "900 and 999 are available"

Closes #5 