### PR TITLE
ISO-4217: Replace old belarussian ruble BYR with BYN

### DIFF
--- a/countries.go
+++ b/countries.go
@@ -2551,7 +2551,7 @@ func (c CountryCode) Currency() CurrencyCode { //nolint:gocyclo
 	case BHR:
 		return CurrencyBHD
 	case BLR:
-		return CurrencyBYR
+		return CurrencyBYN
 	case BLZ:
 		return CurrencyBZD
 	case BEL:

--- a/currencies.go
+++ b/currencies.go
@@ -79,7 +79,7 @@ func (c CurrencyCode) String() string { //nolint:gocyclo
 		return "Taka"
 	case 52:
 		return "Barbados Dollar"
-	case 974:
+	case 933:
 		return "Belarussian Ruble"
 	case 84:
 		return "Belize Dollar"
@@ -425,8 +425,8 @@ func (c CurrencyCode) Alpha() string { //nolint:gocyclo
 		return "BDT"
 	case 52:
 		return "BBD"
-	case 974:
-		return "BYR"
+	case 933:
+		return "BYN"
 	case 84:
 		return "BZD"
 	case 952:
@@ -768,7 +768,7 @@ func (c CurrencyCode) Countries() []CountryCode { //nolint:gocyclo
 		return []CountryCode{PAN}
 	case CurrencyBBD:
 		return []CountryCode{BRB}
-	case CurrencyBYR:
+	case CurrencyBYN:
 		return []CountryCode{BLR}
 	case CurrencyBZD:
 		return []CountryCode{BLZ}
@@ -1099,7 +1099,7 @@ func AllCurrencies() []CurrencyCode {
 		CurrencyBHD,
 		CurrencyBDT,
 		CurrencyBBD,
-		CurrencyBYR,
+		CurrencyBYN,
 		CurrencyBZD,
 		CurrencyXOF,
 		CurrencyBMD,
@@ -1290,7 +1290,7 @@ func (c CurrencyCode) Digits() int { //nolint:gocyclo
 		return 2
 	case CurrencyBBD:
 		return 2
-	case CurrencyBYR:
+	case CurrencyBYN:
 		return 0
 	case CurrencyBZD:
 		return 2
@@ -1693,8 +1693,8 @@ func CurrencyCodeByName(name string) CurrencyCode { //nolint:gocyclo
 		return CurrencyBDT
 	case "BBD", "BARBADOSDOLLAR":
 		return CurrencyBBD
-	case "BYR", "BELARUSSIANRUBLE":
-		return CurrencyBYR
+	case "BYN", "BELARUSSIANRUBLE":
+		return CurrencyBYN
 	case "BZD", "BELIZEDOLLAR":
 		return CurrencyBZD
 	case "XOF", "CFAFRANCBCEAO":

--- a/currenciesconst.go
+++ b/currenciesconst.go
@@ -25,7 +25,7 @@ const (
 	CurrencyBahrainiDinar                  CurrencyCode = 48
 	CurrencyTaka                           CurrencyCode = 50
 	CurrencyBarbadosDollar                 CurrencyCode = 52
-	CurrencyBelarussianRuble               CurrencyCode = 974
+	CurrencyBelarussianRuble               CurrencyCode = 933
 	CurrencyBelizeDollar                   CurrencyCode = 84
 	CurrencyCFAFrancBCEAO                  CurrencyCode = 952
 	CurrencyBermudianDollar                CurrencyCode = 60
@@ -201,7 +201,7 @@ const (
 	CurrencyBHD CurrencyCode = 48
 	CurrencyBDT CurrencyCode = 50
 	CurrencyBBD CurrencyCode = 52
-	CurrencyBYR CurrencyCode = 974
+	CurrencyBYN CurrencyCode = 933
 	CurrencyBZD CurrencyCode = 84
 	CurrencyXOF CurrencyCode = 952
 	CurrencyBMD CurrencyCode = 60


### PR DESCRIPTION
Replaced old BYR to BYN according to ISO 4217
https://en.wikipedia.org/wiki/ISO_4217
