### PR TITLE
fix module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/royshahaf/countries
+module github.com/biter777/countries
 
 go 1.13


### PR DESCRIPTION
There was a change inside `go.mod` which changes the name of the module. Since I think this was a mistake this pr revokes this change and resets the module name back to the original one.