### PR TITLE
updated IQD digits from 0 to 3

### DIFF
--- a/currencies.go
+++ b/currencies.go
@@ -1409,7 +1409,7 @@ func (c CurrencyCode) Digits() int { //nolint:gocyclo
 	case CurrencyIRR:
 		return 0
 	case CurrencyIQD:
-		return 0
+		return 3
 	case CurrencyILS:
 		return 2
 	case CurrencyJMD:


### PR DESCRIPTION
IQD seems to have 3 rather 0 digits. 

Sources https://docs.adyen.com/development-resources/currency-codes, http://www.londonfx.co.uk/ccylist.html