### PR TITLE
Fix the Brazil code 76(not used, old Cruzeiro currency) to 986(Real c…

### DIFF
--- a/countries.go
+++ b/countries.go
@@ -154,6 +154,7 @@ func (_ CountryCode) Type() string {
 }
 
 // String - implements fmt.Stringer, returns a english name of country
+//
 //nolint:gocyclo
 func (c CountryCode) String() string { //nolint:gocyclo
 	switch c {
@@ -213,7 +214,7 @@ func (c CountryCode) String() string { //nolint:gocyclo
 		return "Botswana"
 	case 74:
 		return "Bouvet Island"
-	case 76:
+	case 986:
 		return "Brazil"
 	case 86:
 		return "British Indian Ocean Territory"
@@ -690,6 +691,7 @@ func (c CountryCode) String() string { //nolint:gocyclo
 }
 
 // StringRus - returns a russian name of country
+//
 //nolint:gocyclo
 func (c CountryCode) StringRus() string { //nolint:gocyclo
 	switch c {
@@ -749,7 +751,7 @@ func (c CountryCode) StringRus() string { //nolint:gocyclo
 		return "Ботсвана"
 	case 74:
 		return "остров Буве"
-	case 76:
+	case 986:
 		return "Бразилия"
 	case 86:
 		return "Британские территории Индийского океана"
@@ -1226,6 +1228,7 @@ func (c CountryCode) StringRus() string { //nolint:gocyclo
 }
 
 // Alpha2 - returns a default Alpha (Alpha-2/ISO2, 2 chars) code of country
+//
 //nolint:gocyclo
 func (c CountryCode) Alpha2() string { //nolint:gocyclo
 	switch c {
@@ -1285,7 +1288,7 @@ func (c CountryCode) Alpha2() string { //nolint:gocyclo
 		return "BW"
 	case 74:
 		return "BV"
-	case 76:
+	case 986:
 		return "BR"
 	case 86:
 		return "IO"
@@ -1762,6 +1765,7 @@ func (c CountryCode) Alpha2() string { //nolint:gocyclo
 }
 
 // Alpha3 - returns a Alpha-3 (ISO3, 3 chars) code of country
+//
 //nolint:gocyclo
 func (c CountryCode) Alpha3() string { //nolint:gocyclo
 	switch c {
@@ -1821,7 +1825,7 @@ func (c CountryCode) Alpha3() string { //nolint:gocyclo
 		return "BWA"
 	case 74:
 		return "BVT"
-	case 76:
+	case 986:
 		return "BRA"
 	case 86:
 		return "IOT"
@@ -2321,6 +2325,7 @@ func (c CountryCode) FIFA() string {
 }
 
 // IOC - returns The International Olympic Committee (IOC) three-letter abbreviation country codes
+//
 //nolint:gocyclo
 func (c CountryCode) IOC() string { //nolint:gocyclo
 	switch c {
@@ -2509,6 +2514,7 @@ func (c CountryCode) IOC() string { //nolint:gocyclo
 }
 
 // Currency - returns a currency of the country
+//
 //nolint:gocyclo
 func (c CountryCode) Currency() CurrencyCode { //nolint:gocyclo
 	switch c {
@@ -3284,6 +3290,7 @@ func AllNonCountries() []CountryCode {
 }
 
 // CallCodes - return calling code of country
+//
 //nolint:gocyclo
 func (c CountryCode) CallCodes() []CallCode { //nolint:gocyclo
 	switch c {
@@ -3830,6 +3837,7 @@ func (c CountryCode) Domain() DomainCode {
 }
 
 // Region - return Region code ot the country
+//
 //nolint:gocyclo
 func (c CountryCode) Region() RegionCode { //nolint:gocyclo
 	switch c {
@@ -4347,6 +4355,7 @@ func (c CountryCode) Region() RegionCode { //nolint:gocyclo
 }
 
 // Capital - return a capital of country
+//
 //nolint:gocyclo
 func (c CountryCode) Capital() CapitalCode { //nolint:gocyclo
 	switch c {
@@ -4913,7 +4922,6 @@ func (country *Country) Scan(src interface{}) error {
 	return nil
 }
 
-//
 // AllInfo - return all currencies as []Currency
 func AllInfo() []*Country {
 	all := All()
@@ -4926,6 +4934,7 @@ func AllInfo() []*Country {
 
 // ByName - return CountryCode by country Alpha-2 / Alpha-3 / name, case-insensitive, example: rus := ByName("Ru") OR rus := ByName("russia"),
 // returns countries.Unknown, if country name not found or not valid
+//
 //nolint:misspell,gocyclo
 func ByName(name string) CountryCode { //nolint:misspell,gocyclo
 	switch textPrepare(name) {
@@ -5383,7 +5392,7 @@ func ByName(name string) CountryCode { //nolint:misspell,gocyclo
 		return CAF
 	case "TD", "TCD", "CHAD", "TSCHAD":
 		return TCD
-	case "CZ", "CZE",  "CZECHIA", "CZECHIYA", "CZECHREPUBLIC", "REPUBLICOFCZECH", "CZECH", "TSCHECHIEN", "CHEHIA", "CHEHIYA":
+	case "CZ", "CZE", "CZECHIA", "CZECHIYA", "CZECHREPUBLIC", "REPUBLICOFCZECH", "CZECH", "TSCHECHIEN", "CHEHIA", "CHEHIYA":
 		return CZE
 	case "CL", "CHL", "RCH", "CHILE":
 		return CHL

--- a/countries_test.go
+++ b/countries_test.go
@@ -33,6 +33,10 @@ func TestCountriesByName(t *testing.T) {
 	if countryCodeOut != XSC {
 		t.Errorf("Test ByName() err, want %v, got %v", XSC, countryCodeOut)
 	}
+	countryCodeOut = ByName("BRAZIL")
+	if countryCodeOut != BRA {
+		t.Errorf("Test ByName() err, want %v, got %v", BRA, countryCodeOut)
+	}
 	countryCodeOut = ByName("pupok")
 	if countryCodeOut != Unknown {
 		t.Errorf("Test ByName() err, want %v, got %v", Unknown, countryCodeOut)
@@ -54,6 +58,11 @@ func TestCountriesByNumeric(t *testing.T) {
 	countryCodeOut := ByNumeric(100500999)
 	if countryCodeOut != Unknown {
 		t.Errorf("Test ByNumeric() err, want %v, got %v", Unknown, countryCodeOut)
+	}
+
+	countryCodeBRA := ByNumeric(986)
+	if countryCodeBRA != Brazil {
+		t.Errorf("Test ByNumeric() err, want %v, got %v", Brazil, countryCodeBRA)
 	}
 }
 

--- a/countriesconst.go
+++ b/countriesconst.go
@@ -71,8 +71,8 @@ const (
 	Botswana CountryCode = 72
 	// Bouvet                                 CountryCode = 74
 	Bouvet CountryCode = 74
-	// Brazil                                 CountryCode = 76
-	Brazil CountryCode = 76
+	// Brazil                                 CountryCode = 986
+	Brazil CountryCode = 986
 	// BritishIndianOceanTerritory            CountryCode = 86
 	BritishIndianOceanTerritory CountryCode = 86
 	// Brunei                                 CountryCode = 96
@@ -619,8 +619,8 @@ const (
 	BW CountryCode = 72
 	// BV CountryCode = 74
 	BV CountryCode = 74
-	// BR CountryCode = 76
-	BR CountryCode = 76
+	// BR CountryCode = 986
+	BR CountryCode = 986
 	// IO CountryCode = 86
 	IO CountryCode = 86
 	// BN CountryCode = 96
@@ -1131,8 +1131,8 @@ const (
 	BWA CountryCode = 72
 	// BVT CountryCode = 74
 	BVT CountryCode = 74
-	// BRA CountryCode = 76
-	BRA CountryCode = 76
+	// BRA CountryCode = 986
+	BRA CountryCode = 986
 	// IOT CountryCode = 86
 	IOT CountryCode = 86
 	// BRN CountryCode = 96

--- a/data/iso-codes/data_iso_3166-1.json
+++ b/data/iso-codes/data_iso_3166-1.json
@@ -216,7 +216,7 @@
       "alpha_2": "BR",
       "alpha_3": "BRA",
       "name": "Brazil",
-      "numeric": "076",
+      "numeric": "986",
       "official_name": "Federative Republic of Brazil"
     },
     {


### PR DESCRIPTION
I use this lib, soo when I started to test for Brazil, I got a problem because the lib just accept the code 76 for Brazil currency. But as we can see at https://pt.wikipedia.org/wiki/ISO_4217, the code 76 is for a very old Brazil currency named as Cruzeiro that is no longer valid since 30 years ago. The correct Brazil code is 986 for currency named as Real.