### PR TITLE
Add Eswatini and Kingdon of Eswatini to Swaziland

### DIFF
--- a/countries.go
+++ b/countries.go
@@ -5291,7 +5291,7 @@ func ByName(name string) CountryCode { //nolint:misspell,gocyclo
 		return STP
 	case "SA", "SAU", "SAUDIARABIA", "SAUDI", "SAUDIARABIEN":
 		return SAU
-	case "SZ", "SWZ", "SWAZILAND", "SWASILAND":
+	case "SZ", "SWZ", "SWAZILAND", "SWASILAND", "ESWATINI", "KINGDOMOFESWATINI":
 		return SWZ
 	case "SC", "SYC", "SEYCHELLES", "SEYCHELLEN":
 		return SYC


### PR DESCRIPTION
Eswatini was renamed to Swaziland in 2018 (according to [Wikipedia](https://en.wikipedia.org/wiki/Eswatini)) and Eswatini is still used in many places