### PR TITLE
Replace old VEF currency code to VES

### DIFF
--- a/countries.go
+++ b/countries.go
@@ -2589,7 +2589,7 @@ func (c CountryCode) Currency() CurrencyCode { //nolint:gocyclo
 	case HUN:
 		return CurrencyHUF
 	case VEN:
-		return CurrencyVEF
+		return CurrencyVES
 	case VGB:
 		return CurrencyUSD
 	case VIR:

--- a/currencies.go
+++ b/currencies.go
@@ -371,7 +371,7 @@ func (c CurrencyCode) String() string { //nolint:gocyclo
 		return "Uzbekistan Sum"
 	case 548:
 		return "Vatu"
-	case 937:
+	case 928:
 		return "Bolivar"
 	case 704:
 		return "Dong"
@@ -717,8 +717,8 @@ func (c CurrencyCode) Alpha() string { //nolint:gocyclo
 		return "UZS"
 	case 548:
 		return "VUV"
-	case 937:
-		return "VEF"
+	case 928:
+		return "VES"
 	case 704:
 		return "VND"
 	case 886:
@@ -774,7 +774,7 @@ func (c CurrencyCode) Countries() []CountryCode { //nolint:gocyclo
 		return []CountryCode{BLZ}
 	case CurrencyBMD:
 		return []CountryCode{BMU}
-	case CurrencyVEF:
+	case CurrencyVES:
 		return []CountryCode{VEN}
 	case CurrencyBOB:
 		return []CountryCode{BOL}
@@ -1245,7 +1245,7 @@ func AllCurrencies() []CurrencyCode {
 		CurrencyUYU,
 		CurrencyUZS,
 		CurrencyVUV,
-		CurrencyVEF,
+		CurrencyVES,
 		CurrencyVND,
 		CurrencyYER,
 		CurrencyZMW,
@@ -1582,7 +1582,7 @@ func (c CurrencyCode) Digits() int { //nolint:gocyclo
 		return 0
 	case CurrencyVUV:
 		return 0
-	case CurrencyVEF:
+	case CurrencyVES:
 		return 2
 	case CurrencyVND:
 		return 0
@@ -1987,8 +1987,8 @@ func CurrencyCodeByName(name string) CurrencyCode { //nolint:gocyclo
 		return CurrencyUZS
 	case "VUV", "VATU":
 		return CurrencyVUV
-	case "VEF", "BOLIVAR":
-		return CurrencyVEF
+	case "VES", "BOLIVAR":
+		return CurrencyVES
 	case "VND", "DONG":
 		return CurrencyVND
 	case "YER", "YEMENIRIAL":

--- a/currenciesconst.go
+++ b/currenciesconst.go
@@ -174,7 +174,7 @@ const (
 	CurrencyPesoUruguayo                   CurrencyCode = 858
 	CurrencyUzbekistanSum                  CurrencyCode = 860
 	CurrencyVatu                           CurrencyCode = 548
-	CurrencyBolivar                        CurrencyCode = 937
+	CurrencyBolivar                        CurrencyCode = 928
 	CurrencyDong                           CurrencyCode = 704
 	CurrencyYemeniRial                     CurrencyCode = 886
 	CurrencyZambianKwacha                  CurrencyCode = 967
@@ -347,7 +347,7 @@ const (
 	CurrencyUYU CurrencyCode = 858
 	CurrencyUZS CurrencyCode = 860
 	CurrencyVUV CurrencyCode = 548
-	CurrencyVEF CurrencyCode = 937
+	CurrencyVES CurrencyCode = 928
 	CurrencyVND CurrencyCode = 704
 	CurrencyYER CurrencyCode = 886
 	CurrencyZMW CurrencyCode = 967


### PR DESCRIPTION
Venezuela currency code changed from VEF to VES. Updated it according to ISO
https://en.wikipedia.org/wiki/ISO_4217
Subdivisions are not changed
https://www.iso.org/obp/ui/#iso:code:3166:VE
