### PR TITLE
Fix: change currency code for Chile from CLF to CLP

### DIFF
--- a/countries.go
+++ b/countries.go
@@ -2973,7 +2973,7 @@ func (c CountryCode) Currency() CurrencyCode { //nolint:gocyclo
 	case CZE:
 		return CurrencyCZK
 	case CHL:
-		return CurrencyCLF
+		return CurrencyCLP
 	case CHE:
 		return CurrencyCHF
 	case SWE:


### PR DESCRIPTION
The original issue was reported in #31 and https://github.com/biter777/countries/commit/47f111525f0550b396054aba28eefb12507ae69d has made some changes in `currencies.go` file.

But it doesn't entirely fix the issue, since we need to change `countries.go` file as well, so that `countries.ByName("CL").Info().Currency` should return `CurrencyCLP`.