### PR TITLE
countries: fix Brazil country code. fix #51

### DIFF
--- a/countries.go
+++ b/countries.go
@@ -217,7 +217,7 @@ func (c CountryCode) String() string { //nolint:gocyclo
 	case 74:
 		return "Bouvet Island"
 	case 76:
-		return "Brazil (deprecated)"
+		return "Brazil"
 	case 86:
 		return "British Indian Ocean Territory"
 	case 96:
@@ -664,8 +664,6 @@ func (c CountryCode) String() string { //nolint:gocyclo
 		return "South Sudan"
 	case 900:
 		return "Kosovo"
-	case 986:
-		return "Brazil"
 	case 998:
 		return "None"
 	case 999:
@@ -756,7 +754,7 @@ func (c CountryCode) StringRus() string { //nolint:gocyclo
 	case 74:
 		return "остров Буве"
 	case 76:
-		return "Бразилия (устарело)"
+		return "Бразилия"
 	case 86:
 		return "Британские территории Индийского океана"
 	case 96:
@@ -1203,8 +1201,6 @@ func (c CountryCode) StringRus() string { //nolint:gocyclo
 		return "Южный Судан"
 	case 900:
 		return "Косово"
-	case 986:
-		return "Бразилия"
 	case None:
 		return "Отсутствует"
 	case International:
@@ -1294,7 +1290,7 @@ func (c CountryCode) Alpha2() string { //nolint:gocyclo
 		return "BW"
 	case 74:
 		return "BV"
-	case 76, 986:
+	case 76:
 		return "BR"
 	case 86:
 		return "IO"
@@ -1831,7 +1827,7 @@ func (c CountryCode) Alpha3() string { //nolint:gocyclo
 		return "BWA"
 	case 74:
 		return "BVT"
-	case 76, 986:
+	case 76:
 		return "BRA"
 	case 86:
 		return "IOT"

--- a/countries_test.go
+++ b/countries_test.go
@@ -55,7 +55,7 @@ func TestCountriesByNumeric(t *testing.T) {
 			t.Errorf("Test ByNumeric() err, want %v, got %v", c, countryCodeOut)
 		}
 	}
-	countryCodeBRA := ByNumeric(986)
+	countryCodeBRA := ByNumeric(76)
 	if countryCodeBRA != Brazil {
 		t.Errorf("Test ByNumeric() err, want %v, got %v", Brazil, countryCodeBRA)
 	}

--- a/countriesconst.go
+++ b/countriesconst.go
@@ -71,10 +71,8 @@ const (
 	Botswana CountryCode = 72
 	// Bouvet                                 CountryCode = 74
 	Bouvet CountryCode = 74
-	// Brazil (deprecated)                    CountryCode = 76
-	BrazilDeprecated CountryCode = 76
-	// Brazil                                 CountryCode = 986
-	Brazil CountryCode = 986
+	// Brazil                                 CountryCode = 76
+	Brazil CountryCode = 76
 	// BritishIndianOceanTerritory            CountryCode = 86
 	BritishIndianOceanTerritory CountryCode = 86
 	// Brunei                                 CountryCode = 96
@@ -621,8 +619,8 @@ const (
 	BW CountryCode = 72
 	// BV CountryCode = 74
 	BV CountryCode = 74
-	// BR CountryCode = 986
-	BR CountryCode = 986
+	// BR CountryCode = 76
+	BR CountryCode = 76
 	// IO CountryCode = 86
 	IO CountryCode = 86
 	// BN CountryCode = 96
@@ -1133,8 +1131,8 @@ const (
 	BWA CountryCode = 72
 	// BVT CountryCode = 74
 	BVT CountryCode = 74
-	// BRA CountryCode = 986
-	BRA CountryCode = 986
+	// BRA CountryCode = 76
+	BRA CountryCode = 76
 	// IOT CountryCode = 86
 	IOT CountryCode = 86
 	// BRN CountryCode = 96


### PR DESCRIPTION
Hi there @biter777!

This pull request is intended to fix issue #51. The issue author is my coworker and this fix is particularly important for the system we are working on.

The [previous pull request](https://github.com/biter777/countries/pull/39) related to Brazil's code introduced this bug, in an attempt to fix another bug. But I believe both bugs are now fixed in this new pull request, both Brazil's country code (76) and currency code (986).

For reference, [this webpage](https://codesofcountry.com/countries/br) can be checked regarding the correct codes for Brazil.

Thanks!