### PR TITLE
RSD uses 2 minor digits

### DIFF
--- a/currencies.go
+++ b/currencies.go
@@ -1528,7 +1528,7 @@ func (c CurrencyCode) Digits() int { //nolint:gocyclo
 	case CurrencySAR:
 		return 2
 	case CurrencyRSD:
-		return 0
+		return 2
 	case CurrencySCR:
 		return 2
 	case CurrencySLL:


### PR DESCRIPTION
The Serbian Dinar uses 2 minor digits according to [ISO 4217](https://datahub.io/core/currency-codes)